### PR TITLE
build(release): Go modules for ContinuumLLC fork

### DIFF
--- a/autoload/windows.go
+++ b/autoload/windows.go
@@ -1,10 +1,10 @@
 // Package autoload automatically calls OverrideEnvWithStaticProxy,
 // which writes new values to the `http_proxy`, `https_proxy` and `no_proxy` environment variables.
 // The values are taken from the Windows Regedit
-// import _ "github.com/mattn/go-ieproxy/autoload"
+// import _ "github.com/ContinuumLLC/go-ieproxy/autoload"
 package autoload
 
-import ieproxy "github.com/mattn/go-ieproxy"
+import ieproxy "github.com/ContinuumLLC/go-ieproxy"
 
 func init() {
 	ieproxy.OverrideEnvWithStaticProxy()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/mattn/go-ieproxy
+module github.com/ContinuumLLC/go-ieproxy
 
-go 1.14
+go 1.15
 
 require (
 	golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4


### PR DESCRIPTION
1. Change import path
2. Change go.mod to use ContinuumLLC fork
3. Change go.mod to use Go 1.15